### PR TITLE
Take out the entry point build to CommandBuilder

### DIFF
--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/CommandBuilder.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/CommandBuilder.java
@@ -21,12 +21,24 @@ SOFTWARE.
 */
 package com.dwolfnineteen.jdaextra.builders;
 
+import com.dwolfnineteen.jdaextra.annotations.ExtraMainCommand;
 import com.dwolfnineteen.jdaextra.commands.Command;
 import com.dwolfnineteen.jdaextra.models.CommandModel;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Method;
 
 public abstract class CommandBuilder {
     protected Command command;
 
-    // TODO: remove duplicate code
     public abstract CommandModel buildModel();
+
+    @Nullable
+    protected Method buildMain() {
+        for (Method method : command.getClass().getDeclaredMethods())
+            if (method.isAnnotationPresent(ExtraMainCommand.class))
+                return method;
+
+        return null;
+    }
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/HybridCommandBuilder.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/HybridCommandBuilder.java
@@ -22,15 +22,12 @@ SOFTWARE.
 package com.dwolfnineteen.jdaextra.builders;
 
 import com.dwolfnineteen.jdaextra.annotations.ExtraHybridCommand;
-import com.dwolfnineteen.jdaextra.annotations.ExtraMainCommand;
 import com.dwolfnineteen.jdaextra.commands.HybridCommand;
 import com.dwolfnineteen.jdaextra.commands.Command;
 import com.dwolfnineteen.jdaextra.exceptions.CommandAnnotationNotFoundException;
 import com.dwolfnineteen.jdaextra.models.HybridCommandModel;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.lang.reflect.Method;
 
 public class HybridCommandBuilder extends CommandBuilder {
     public HybridCommandBuilder(@NotNull HybridCommand command) {
@@ -44,14 +41,7 @@ public class HybridCommandBuilder extends CommandBuilder {
         Class<? extends Command> commandClass = command.getClass();
 
         model.setCommand(command);
-
-        for (Method method : command.getClass().getDeclaredMethods()) {
-            if (method.isAnnotationPresent(ExtraMainCommand.class)) {
-                model.setMain(method);
-
-                break;
-            }
-        }
+        model.setMain(buildMain());
 
         if (commandClass.isAnnotationPresent(ExtraHybridCommand.class)) {
             ExtraHybridCommand classAnnotation = commandClass.getAnnotation(ExtraHybridCommand.class);

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/PrefixCommandBuilder.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/PrefixCommandBuilder.java
@@ -21,7 +21,6 @@ SOFTWARE.
 */
 package com.dwolfnineteen.jdaextra.builders;
 
-import com.dwolfnineteen.jdaextra.annotations.ExtraMainCommand;
 import com.dwolfnineteen.jdaextra.annotations.ExtraPrefixCommand;
 import com.dwolfnineteen.jdaextra.commands.PrefixCommand;
 import com.dwolfnineteen.jdaextra.commands.Command;
@@ -29,8 +28,6 @@ import com.dwolfnineteen.jdaextra.exceptions.CommandAnnotationNotFoundException;
 import com.dwolfnineteen.jdaextra.models.PrefixCommandModel;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.lang.reflect.Method;
 
 public class PrefixCommandBuilder extends CommandBuilder {
     public PrefixCommandBuilder(@NotNull PrefixCommand command) {
@@ -44,14 +41,7 @@ public class PrefixCommandBuilder extends CommandBuilder {
         Class<? extends Command> commandClass = command.getClass();
 
         model.setCommand(command);
-
-        for (Method method : commandClass.getDeclaredMethods()) {
-            if (method.isAnnotationPresent(ExtraMainCommand.class)) {
-                model.setMain(method);
-
-                break;
-            }
-        }
+        model.setMain(buildMain());
 
         if (commandClass.isAnnotationPresent(ExtraPrefixCommand.class)) {
             ExtraPrefixCommand classAnnotation = commandClass.getAnnotation(ExtraPrefixCommand.class);

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/SlashCommandBuilder.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/SlashCommandBuilder.java
@@ -21,7 +21,6 @@ SOFTWARE.
 */
 package com.dwolfnineteen.jdaextra.builders;
 
-import com.dwolfnineteen.jdaextra.annotations.ExtraMainCommand;
 import com.dwolfnineteen.jdaextra.annotations.ExtraSlashCommand;
 import com.dwolfnineteen.jdaextra.commands.Command;
 import com.dwolfnineteen.jdaextra.commands.SlashCommand;
@@ -30,7 +29,6 @@ import com.dwolfnineteen.jdaextra.models.SlashCommandModel;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.reflect.Method;
 
 public class SlashCommandBuilder extends CommandBuilder {
     public SlashCommandBuilder(@NotNull SlashCommand command) {
@@ -44,14 +42,9 @@ public class SlashCommandBuilder extends CommandBuilder {
         Class<? extends Command> commandClass = command.getClass();
 
         model.setCommand(command);
+        model.setMain(buildMain());
 
-        for (Method method : command.getClass().getDeclaredMethods()) {
-            if (method.isAnnotationPresent(ExtraMainCommand.class)) {
-                model.setMain(method);
 
-                break;
-            }
-        }
 
         if (commandClass.isAnnotationPresent(ExtraSlashCommand.class)) {
             ExtraSlashCommand classAnnotation = commandClass.getAnnotation(ExtraSlashCommand.class);


### PR DESCRIPTION
### Changes
- ✅ Internal
- ❌ Interface (affects end-user code) 
- ❌ Docs
- ❌ Metadata (README, copyright, Git files, files in `.github`, etc)
- ❌ Other: ...
### Description
Take out the entry point build to `CommandBuilder`. This will remove the duplicated code.
