### PR TITLE
Remove CI run on push to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - "main"
-    paths:
-      - "**.java"
-      - "**.kts"
   pull_request:
     types:
       - opened


### PR DESCRIPTION
### Changes
- ❌ Internal
- ❌ Interface (affects end-user code) 
- ❌ Docs
- ✅ Metadata (README, copyright, Git files, files in `.github`, etc)
- ❌ Other: ...
### Description
Remove CI run on push to main branch. It's not necessary.
