### PR TITLE
Rename Command abs class to BaseCommand

### DIFF
--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/CommandBuilder.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/CommandBuilder.java
@@ -22,14 +22,14 @@ SOFTWARE.
 package com.dwolfnineteen.jdaextra.builders;
 
 import com.dwolfnineteen.jdaextra.annotations.ExtraMainCommand;
-import com.dwolfnineteen.jdaextra.commands.Command;
+import com.dwolfnineteen.jdaextra.commands.BaseCommand;
 import com.dwolfnineteen.jdaextra.models.CommandModel;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Method;
 
 public abstract class CommandBuilder {
-    protected Command command;
+    protected BaseCommand command;
 
     public abstract CommandModel buildModel();
 

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/HybridCommandBuilder.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/HybridCommandBuilder.java
@@ -22,8 +22,8 @@ SOFTWARE.
 package com.dwolfnineteen.jdaextra.builders;
 
 import com.dwolfnineteen.jdaextra.annotations.ExtraHybridCommand;
+import com.dwolfnineteen.jdaextra.commands.BaseCommand;
 import com.dwolfnineteen.jdaextra.commands.HybridCommand;
-import com.dwolfnineteen.jdaextra.commands.Command;
 import com.dwolfnineteen.jdaextra.exceptions.CommandAnnotationNotFoundException;
 import com.dwolfnineteen.jdaextra.models.HybridCommandModel;
 import org.jetbrains.annotations.NotNull;
@@ -38,7 +38,7 @@ public class HybridCommandBuilder extends CommandBuilder {
     @Nullable
     public HybridCommandModel buildModel() {
         HybridCommandModel model = new HybridCommandModel();
-        Class<? extends Command> commandClass = command.getClass();
+        Class<? extends BaseCommand> commandClass = command.getClass();
 
         model.setCommand(command);
         model.setMain(buildMain());

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/PrefixCommandBuilder.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/PrefixCommandBuilder.java
@@ -22,8 +22,8 @@ SOFTWARE.
 package com.dwolfnineteen.jdaextra.builders;
 
 import com.dwolfnineteen.jdaextra.annotations.ExtraPrefixCommand;
+import com.dwolfnineteen.jdaextra.commands.BaseCommand;
 import com.dwolfnineteen.jdaextra.commands.PrefixCommand;
-import com.dwolfnineteen.jdaextra.commands.Command;
 import com.dwolfnineteen.jdaextra.exceptions.CommandAnnotationNotFoundException;
 import com.dwolfnineteen.jdaextra.models.PrefixCommandModel;
 import org.jetbrains.annotations.NotNull;
@@ -38,7 +38,7 @@ public class PrefixCommandBuilder extends CommandBuilder {
     @Nullable
     public PrefixCommandModel buildModel() {
         PrefixCommandModel model = new PrefixCommandModel();
-        Class<? extends Command> commandClass = command.getClass();
+        Class<? extends BaseCommand> commandClass = command.getClass();
 
         model.setCommand(command);
         model.setMain(buildMain());

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/SlashCommandBuilder.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/SlashCommandBuilder.java
@@ -22,13 +22,12 @@ SOFTWARE.
 package com.dwolfnineteen.jdaextra.builders;
 
 import com.dwolfnineteen.jdaextra.annotations.ExtraSlashCommand;
-import com.dwolfnineteen.jdaextra.commands.Command;
+import com.dwolfnineteen.jdaextra.commands.BaseCommand;
 import com.dwolfnineteen.jdaextra.commands.SlashCommand;
 import com.dwolfnineteen.jdaextra.exceptions.CommandAnnotationNotFoundException;
 import com.dwolfnineteen.jdaextra.models.SlashCommandModel;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
 
 public class SlashCommandBuilder extends CommandBuilder {
     public SlashCommandBuilder(@NotNull SlashCommand command) {
@@ -39,12 +38,10 @@ public class SlashCommandBuilder extends CommandBuilder {
     @Nullable
     public SlashCommandModel buildModel() {
         SlashCommandModel model = new SlashCommandModel();
-        Class<? extends Command> commandClass = command.getClass();
+        Class<? extends BaseCommand> commandClass = command.getClass();
 
         model.setCommand(command);
         model.setMain(buildMain());
-
-
 
         if (commandClass.isAnnotationPresent(ExtraSlashCommand.class)) {
             ExtraSlashCommand classAnnotation = commandClass.getAnnotation(ExtraSlashCommand.class);

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/BaseCommand.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/BaseCommand.java
@@ -21,5 +21,5 @@ SOFTWARE.
 */
 package com.dwolfnineteen.jdaextra.commands;
 
-public abstract class Command {
+public abstract class BaseCommand {
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/HybridCommand.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/HybridCommand.java
@@ -21,5 +21,5 @@ SOFTWARE.
 */
 package com.dwolfnineteen.jdaextra.commands;
 
-public abstract class HybridCommand extends Command {
+public abstract class HybridCommand extends BaseCommand {
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/PrefixCommand.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/PrefixCommand.java
@@ -21,5 +21,5 @@ SOFTWARE.
 */
 package com.dwolfnineteen.jdaextra.commands;
 
-public abstract class PrefixCommand extends Command {
+public abstract class PrefixCommand extends BaseCommand {
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/SlashCommand.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/SlashCommand.java
@@ -21,5 +21,5 @@ SOFTWARE.
 */
 package com.dwolfnineteen.jdaextra.commands;
 
-public abstract class SlashCommand extends Command {
+public abstract class SlashCommand extends BaseCommand {
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/models/CommandModel.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/models/CommandModel.java
@@ -21,7 +21,7 @@ SOFTWARE.
 */
 package com.dwolfnineteen.jdaextra.models;
 
-import com.dwolfnineteen.jdaextra.commands.Command;
+import com.dwolfnineteen.jdaextra.commands.BaseCommand;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,7 +29,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 
 public abstract class CommandModel {
-    private Command command;
+    private BaseCommand command;
     private Method main;
     private String name;
     private ArrayList<OptionData> options;
@@ -37,7 +37,7 @@ public abstract class CommandModel {
     private boolean nsfw;
 
     @NotNull
-    public Command getCommand() {
+    public BaseCommand getCommand() {
         return command;
     }
 
@@ -65,7 +65,7 @@ public abstract class CommandModel {
     }
 
     @NotNull
-    public CommandModel setCommand(@NotNull Command command) {
+    public CommandModel setCommand(@NotNull BaseCommand command) {
         this.command = command;
 
         return this;


### PR DESCRIPTION
### Changes
- ❌ Internal
- ✅ Interface (affects end-user code) 
- ❌ Docs
- ❌ Metadata (README, copyright, Git files, files in `.github`, etc)
- ❌ Other: ...
### Description
Rename `Command` abstract class to `BaseCommand`. This will remove intersection with [net.dv8tion.jda.api.interactions.command.Command](https://docs.jda.wiki/net/dv8tion/jda/api/interactions/commands/Command.html). This change can break end-user code, for example, in call:
```java
Command command = jdaExtraInstance.getSlashCommandsModels().get("name").getCommand();
```
->
```java
// Rename Command to BaseCommand
BaseCommand command = jdaExtraInstance.getSlashCommandsModels().get("name").getCommand();
```