### PR TITLE
Split Option annotation to three different

### DIFF
--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/annotations/options/HybridOption.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/annotations/options/HybridOption.java
@@ -1,0 +1,37 @@
+/*
+Copyright (c) 2023 DWolf Nineteen & The JDA-Extra contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package com.dwolfnineteen.jdaextra.annotations.options;
+
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface HybridOption {
+    OptionType type() default OptionType.UNKNOWN;
+    String name() default "";
+    String description();
+}

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/annotations/options/PrefixOption.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/annotations/options/PrefixOption.java
@@ -1,0 +1,37 @@
+/*
+Copyright (c) 2023 DWolf Nineteen & The JDA-Extra contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package com.dwolfnineteen.jdaextra.annotations.options;
+
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface PrefixOption {
+    OptionType type() default OptionType.UNKNOWN;
+    String name() default "";
+    String description() default "";
+}

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/annotations/options/SlashOption.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/annotations/options/SlashOption.java
@@ -30,8 +30,8 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
-public @interface Option {
+public @interface SlashOption {
     OptionType type() default OptionType.UNKNOWN;
     String name() default "";
-    String description() default "";
+    String description();
 }


### PR DESCRIPTION
### Changes
- ❌ Internal
- ✅ Interface (affects end-user code) 
- ❌ Docs
- ❌ Metadata (README, copyright, Git files, files in `.github`, etc)
- ❌ Other: ...
### Description
Split `Option` annotation to three different:
* It's not necessary to specify a description for prefix commands, we need different annotations for prefix/slash commands.
* `HybridOption` added only for semantics (has the same code as `SlashOption`).
