### PR TITLE
Replace "application" plugin to "java" in samples

### DIFF
--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -20,11 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 plugins {
-    application
-}
-
-application {
-    mainClass.set("com.dwolfnineteen.samples.ExampleBot")
+    java
 }
 
 repositories {


### PR DESCRIPTION
### Changes
- ❌ Internal
- ❌ Interface (affects end-user code) 
- ❌ Docs
- ❌ Metadata (README, copyright, Git files, files in `.github`, etc)
- ✅ Other: Change Gradle plugin in samples
### Description
Replace `application` plugin to `java` in samples. We don't need to run anything there!
