### PR TITLE
Add Java 8 toolchain to Gradle in samples

### DIFF
--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -30,3 +30,9 @@ repositories {
 dependencies {
     implementation(project(":lib"))
 }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
+}


### PR DESCRIPTION
### Changes
- ❌ Internal
- ❌ Interface (affects end-user code) 
- ❌ Docs
- ❌ Metadata (README, copyright, Git files, files in `.github`, etc)
- ✅ Other: Change Java toolchain in build.gradle.kts
### Description
Add Java 8 toolchain to Gradle in samples.
