### PR TITLE
Revert "Add JDK, Gradle and CI status badges to README (#89)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # JDA-Extra
 ![JDA-Extra](banner.png)
 ---
-![JDK](https://img.shields.io/badge/Minimum_JDK-8-white?logo=openjdk&link=https%3A%2F%2Fadoptium.net%2Ftemurin%2Freleases%2F)
-![Static Badge](https://img.shields.io/badge/Built_with-Gradle-white?logo=gradle&link=https%3A%2F%2Fgradle.org%2F)
-[![CI](https://github.com/DWolf-19/JDA-Extra/actions/workflows/ci.yml/badge.svg)](https://github.com/DWolf-19/JDA-Extra/actions/workflows/ci.yml)
-
 A modern and evolving commands & components framework for JDA. Inspired by [JDA-Utilities](https://github.com/JDA-Applications/JDA-Utilities) and [BotCommands](https://github.com/freya022/BotCommands).
 # Plans
 In the first alpha we plan to make full support of prefix/slash/hybrid commands, their configuration and events. Context commands/components support will be introduced in the upcoming alpha versions. 


### PR DESCRIPTION
### Changes
- ❌ Internal
- ❌ Interface (affects end-user code)
- ❌ Gradle (wrapper, scripts, dependencies)
- ❌ Docs
- ✅ Metadata (README, copyright, Git files, files in `.github`)
- ❌ Other: ...
### Description
This reverts commit bc151ed22e15034322cfef3bd15e61fc0582f146.

Minimum JDK requirements will be located in a separate section in README. Other icons are useless.