### PR TITLE
Require name in **Option annotations

### DIFF
--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/annotations/options/HybridOption.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/annotations/options/HybridOption.java
@@ -32,6 +32,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 public @interface HybridOption {
     OptionType type() default OptionType.UNKNOWN;
-    String name() default "";
+    String name();
     String description();
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/annotations/options/PrefixOption.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/annotations/options/PrefixOption.java
@@ -32,6 +32,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 public @interface PrefixOption {
     OptionType type() default OptionType.UNKNOWN;
-    String name() default "";
+    String name();
     String description() default "";
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/annotations/options/SlashOption.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/annotations/options/SlashOption.java
@@ -32,6 +32,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 public @interface SlashOption {
     OptionType type() default OptionType.UNKNOWN;
-    String name() default "";
+    String name();
     String description();
 }


### PR DESCRIPTION
### Changes
- ❌Internal
- ✅ Interface (affects end-user code)
- ❌ Gradle (wrapper, scripts, dependencies)
- ❌ Docs
- ❌ Metadata (README, copyright, Git files, files in `.github`)
- ❌ Other: ...
### Description
Fix (maybe temporarily) (I hope so) Java reflection API limitation. See [SO](https://stackoverflow.com/q/2237803/20137863) for more information.
