### PR TITLE
Add custom OptionData for prefix commands

### DIFF
--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/models/CommandModel.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/models/CommandModel.java
@@ -22,17 +22,14 @@ SOFTWARE.
 package com.dwolfnineteen.jdaextra.models;
 
 import com.dwolfnineteen.jdaextra.commands.BaseCommand;
-import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 
 public abstract class CommandModel {
     private BaseCommand command;
     private Method main;
     private String name;
-    private ArrayList<OptionData> options;
     private boolean guildOnly;
     private boolean nsfw;
 
@@ -49,11 +46,6 @@ public abstract class CommandModel {
     @NotNull
     public String getName() {
         return name;
-    }
-
-    @NotNull
-    public ArrayList<OptionData> getOptions() {
-        return options;
     }
 
     public boolean isGuildOnly() {
@@ -80,12 +72,6 @@ public abstract class CommandModel {
 
     public CommandModel setName(@NotNull String name) {
         this.name = name;
-
-        return this;
-    }
-
-    public CommandModel setOptions(@NotNull ArrayList<OptionData> options) {
-        this.options = options;
 
         return this;
     }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/models/HybridCommandModel.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/models/HybridCommandModel.java
@@ -21,10 +21,14 @@ SOFTWARE.
 */
 package com.dwolfnineteen.jdaextra.models;
 
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class HybridCommandModel extends CommandModel {
     private String description;
+    private List<OptionData> options;
 
     @NotNull
     public String getDescription() {
@@ -32,8 +36,20 @@ public class HybridCommandModel extends CommandModel {
     }
 
     @NotNull
+    public List<OptionData> getOptions() {
+        return options;
+    }
+
+    @NotNull
     public HybridCommandModel setDescription(@NotNull String description) {
         this.description = description;
+
+        return this;
+    }
+
+    @NotNull
+    public HybridCommandModel setOptions(@NotNull List<OptionData> options) {
+        this.options = options;
 
         return this;
     }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/models/PrefixCommandModel.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/models/PrefixCommandModel.java
@@ -21,11 +21,15 @@ SOFTWARE.
 */
 package com.dwolfnineteen.jdaextra.models;
 
+import com.dwolfnineteen.jdaextra.prefix.PrefixOptionData;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
+
 public class PrefixCommandModel extends CommandModel {
     private String description;
+    private List<PrefixOptionData> options;
 
     @Nullable
     public String getDescription() {
@@ -33,8 +37,20 @@ public class PrefixCommandModel extends CommandModel {
     }
 
     @NotNull
+    public List<PrefixOptionData> getOptions() {
+        return options;
+    }
+
+    @NotNull
     public PrefixCommandModel setDescription(@Nullable String description) {
         this.description = description;
+
+        return this;
+    }
+
+    @NotNull
+    public PrefixCommandModel setOptions(@NotNull List<PrefixOptionData> options) {
+        this.options = options;
 
         return this;
     }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/models/SlashCommandModel.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/models/SlashCommandModel.java
@@ -21,10 +21,14 @@ SOFTWARE.
 */
 package com.dwolfnineteen.jdaextra.models;
 
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class SlashCommandModel extends CommandModel {
     private String description;
+    private List<OptionData> options;
 
     @NotNull
     public String getDescription() {
@@ -32,8 +36,20 @@ public class SlashCommandModel extends CommandModel {
     }
 
     @NotNull
+    public List<OptionData> getOptions() {
+        return options;
+    }
+
+    @NotNull
     public SlashCommandModel setDescription(@NotNull String description) {
         this.description = description;
+
+        return this;
+    }
+
+    @NotNull
+    public SlashCommandModel setOptions(@NotNull List<OptionData> options) {
+        this.options = options;
 
         return this;
     }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/prefix/PrefixOptionData.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/prefix/PrefixOptionData.java
@@ -1,0 +1,186 @@
+/*
+Copyright (c) 2023 DWolf Nineteen & The JDA-Extra contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package com.dwolfnineteen.jdaextra.prefix;
+
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class PrefixOptionData {
+    private final OptionType type;
+    private String name;
+    private String description;
+    private boolean isRequired;
+    private boolean isAutoComplete;
+    private Number minValue;
+    private Number maxValue;
+    private int minLength;
+    private Integer maxLength;
+
+    public PrefixOptionData(@NotNull OptionType type, @NotNull String name) {
+        this.type = type;
+        this.name = name;
+    }
+
+    public PrefixOptionData(@NotNull OptionType type, @NotNull String name, @Nullable String description) {
+        this.type = type;
+        this.name = name;
+        this.description = description;
+    }
+
+    public PrefixOptionData(@NotNull OptionType type, @NotNull String name, boolean isRequired) {
+        this.type = type;
+        this.name = name;
+        this.isRequired = isRequired;
+    }
+
+    public PrefixOptionData(@NotNull OptionType type,
+                            @NotNull String name,
+                            @Nullable String description,
+                            boolean isRequired) {
+        this.type = type;
+        this.name = name;
+        this.description = description;
+        this.isRequired = isRequired;
+    }
+
+    public PrefixOptionData(@NotNull OptionType type,
+                            @NotNull String name,
+                            boolean isRequired,
+                            boolean isAutoComplete) {
+        this.type = type;
+        this.name = name;
+        this.isRequired = isRequired;
+        this.isAutoComplete = isAutoComplete;
+    }
+
+    public PrefixOptionData(@NotNull OptionType type,
+                            @NotNull String name,
+                            @Nullable String description,
+                            boolean isRequired,
+                            boolean isAutoComplete) {
+        this.type = type;
+        this.name = name;
+        this.description = description;
+        this.isRequired = isRequired;
+        this.isAutoComplete = isAutoComplete;
+    }
+
+    @NotNull
+    public OptionType getType() {
+        return type;
+    }
+
+    @NotNull
+    public String getName() {
+        return name;
+    }
+
+    @Nullable
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean isRequired() {
+        return isRequired;
+    }
+
+    public boolean isAutoComplete() {
+        return isAutoComplete;
+    }
+
+    @Nullable
+    public Number getMinValue() {
+        return minValue;
+    }
+
+    @Nullable
+    public Number getMaxValue() {
+        return maxValue;
+    }
+
+    @Nullable
+    public Integer getMinLength() {
+        return minLength;
+    }
+
+    @Nullable
+    public Integer getMaxLength() {
+        return maxLength;
+    }
+
+    @NotNull
+    public PrefixOptionData setName(@NotNull String name) {
+        this.name = name;
+
+        return this;
+    }
+
+    @NotNull
+    public PrefixOptionData setDescription(@NotNull String description) {
+        this.description = description;
+
+        return this;
+    }
+
+    @NotNull
+    public PrefixOptionData setRequired(boolean required) {
+        isRequired = required;
+
+        return this;
+    }
+
+    @NotNull
+    public PrefixOptionData setAutoComplete(boolean autoComplete) {
+        isAutoComplete = autoComplete;
+
+        return this;
+    }
+
+    @NotNull
+    public PrefixOptionData setMinValue(Number minValue) {
+        this.minValue = minValue;
+
+        return this;
+    }
+
+    @NotNull
+    public PrefixOptionData setMaxValue(Number maxValue) {
+        this.maxValue = maxValue;
+
+        return this;
+    }
+
+    @NotNull
+    public PrefixOptionData setMinLength(int minLength) {
+        this.minLength = minLength;
+
+        return this;
+    }
+
+    @NotNull
+    public PrefixOptionData setMaxLength(Integer maxLength) {
+        this.maxLength = maxLength;
+
+        return this;
+    }
+}


### PR DESCRIPTION
### Changes
- ✅ Internal
- ❌ Interface (affects end-user code)
- ❌ Gradle (wrapper, scripts, dependencies)
- ❌ Docs
- ❌ Metadata (README, copyright, Git files, files in `.github`)
- ❌ Other: ...
### Description
Add custom `OptionData` for prefix commands. This type of commands requires its own solution, since, for example, a description for prefix commands options is optional + there are no "choices" in them.
