### PR TITLE
Add unified interface for option data

### DIFF
--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/models/PrefixCommandModel.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/models/PrefixCommandModel.java
@@ -21,7 +21,7 @@ SOFTWARE.
 */
 package com.dwolfnineteen.jdaextra.models;
 
-import com.dwolfnineteen.jdaextra.prefix.PrefixOptionData;
+import com.dwolfnineteen.jdaextra.options.data.PrefixOptionData;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/options/data/CommandOptionData.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/options/data/CommandOptionData.java
@@ -1,0 +1,45 @@
+/*
+Copyright (c) 2023 DWolf Nineteen & The JDA-Extra contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package com.dwolfnineteen.jdaextra.options.data;
+
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+
+public interface CommandOptionData {
+    OptionType getType();
+    String getName();
+    String getDescription();
+    boolean isRequired();
+    boolean isAutoComplete();
+    Number getMinValue();
+    Number getMaxValue();
+    Integer getMinLength();
+    Integer getMaxLength();
+
+    CommandOptionData setName(String name);
+    CommandOptionData setDescription(String description);
+    CommandOptionData setRequired(boolean required);
+    CommandOptionData setAutoComplete(boolean autoComplete);
+    CommandOptionData setMinValue(Number minValue);
+    CommandOptionData setMaxValue(Number maxValue);
+    CommandOptionData setMinLength(int minLength);
+    CommandOptionData setMaxLength(Integer maxLength);
+}

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/options/data/PrefixOptionData.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/options/data/PrefixOptionData.java
@@ -19,13 +19,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
-package com.dwolfnineteen.jdaextra.prefix;
+package com.dwolfnineteen.jdaextra.options.data;
 
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class PrefixOptionData {
+public class PrefixOptionData implements CommandOptionData {
     private final OptionType type;
     private String name;
     private String description;
@@ -85,49 +85,59 @@ public class PrefixOptionData {
         this.isAutoComplete = isAutoComplete;
     }
 
+    @Override
     @NotNull
     public OptionType getType() {
         return type;
     }
 
+    @Override
     @NotNull
     public String getName() {
         return name;
     }
 
+    @Override
     @Nullable
     public String getDescription() {
         return description;
     }
 
+    @Override
     public boolean isRequired() {
         return isRequired;
     }
 
+    @Override
     public boolean isAutoComplete() {
         return isAutoComplete;
     }
 
+    @Override
     @Nullable
     public Number getMinValue() {
         return minValue;
     }
 
+    @Override
     @Nullable
     public Number getMaxValue() {
         return maxValue;
     }
 
+    @Override
     @Nullable
     public Integer getMinLength() {
         return minLength;
     }
 
+    @Override
     @Nullable
     public Integer getMaxLength() {
         return maxLength;
     }
 
+    @Override
     @NotNull
     public PrefixOptionData setName(@NotNull String name) {
         this.name = name;
@@ -135,6 +145,7 @@ public class PrefixOptionData {
         return this;
     }
 
+    @Override
     @NotNull
     public PrefixOptionData setDescription(@NotNull String description) {
         this.description = description;
@@ -142,6 +153,7 @@ public class PrefixOptionData {
         return this;
     }
 
+    @Override
     @NotNull
     public PrefixOptionData setRequired(boolean required) {
         isRequired = required;
@@ -149,6 +161,7 @@ public class PrefixOptionData {
         return this;
     }
 
+    @Override
     @NotNull
     public PrefixOptionData setAutoComplete(boolean autoComplete) {
         isAutoComplete = autoComplete;
@@ -156,6 +169,7 @@ public class PrefixOptionData {
         return this;
     }
 
+    @Override
     @NotNull
     public PrefixOptionData setMinValue(Number minValue) {
         this.minValue = minValue;
@@ -163,6 +177,7 @@ public class PrefixOptionData {
         return this;
     }
 
+    @Override
     @NotNull
     public PrefixOptionData setMaxValue(Number maxValue) {
         this.maxValue = maxValue;
@@ -170,6 +185,7 @@ public class PrefixOptionData {
         return this;
     }
 
+    @Override
     @NotNull
     public PrefixOptionData setMinLength(int minLength) {
         this.minLength = minLength;
@@ -177,6 +193,7 @@ public class PrefixOptionData {
         return this;
     }
 
+    @Override
     @NotNull
     public PrefixOptionData setMaxLength(Integer maxLength) {
         this.maxLength = maxLength;


### PR DESCRIPTION
### Changes
- ✅ Internal
- ❌ Interface (affects end-user code)
- ❌ Gradle (wrapper, scripts, dependencies)
- ❌ Docs
- ❌ Metadata (README, copyright, Git files, files in `.github`)
- ❌ Other: ...
### Description
Add unified interface for option data. Similar `OptionData` classes for hybrid/slash commands will be added in the future.
