### PR TITLE
Add native commands abstraction

### DIFF
--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/HybridCommand.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/HybridCommand.java
@@ -21,5 +21,5 @@ SOFTWARE.
 */
 package com.dwolfnineteen.jdaextra.commands;
 
-public abstract class HybridCommand extends BaseCommand {
+public abstract class HybridCommand extends NativeCommand {
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/NativeCommand.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/NativeCommand.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 DWolf Nineteen & The JDA-Extra contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.dwolfnineteen.jdaextra.commands;
+
+public abstract class NativeCommand extends BaseCommand {
+}

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/SlashCommand.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/SlashCommand.java
@@ -21,5 +21,5 @@ SOFTWARE.
 */
 package com.dwolfnineteen.jdaextra.commands;
 
-public abstract class SlashCommand extends BaseCommand {
+public abstract class SlashCommand extends NativeCommand {
 }


### PR DESCRIPTION
### Changes
- ✅ Internal
- ✅ Interface (affects end-user code)
- ❌ Gradle (wrapper, scripts, dependencies)
- ❌ Docs
- ❌ Metadata (README, copyright, Git files, files in `.github`)
- ❌ Other: ...
### Description
This PR adds new abstraction: native command. This change takes out slash/hybrid commands to a separate branch from prefix commands. `NativeCommand` is a base class for commands that can be executed as slash.
