### PR TITLE
Add custom option data for all commands

### DIFF
--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/options/data/CommandOptionData.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/options/data/CommandOptionData.java
@@ -21,7 +21,10 @@ SOFTWARE.
 */
 package com.dwolfnineteen.jdaextra.options.data;
 
+import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
+
+import java.util.Collection;
 
 public interface CommandOptionData {
     OptionType getType();
@@ -38,8 +41,19 @@ public interface CommandOptionData {
     CommandOptionData setDescription(String description);
     CommandOptionData setRequired(boolean required);
     CommandOptionData setAutoComplete(boolean autoComplete);
-    CommandOptionData setMinValue(Number minValue);
-    CommandOptionData setMaxValue(Number maxValue);
+    CommandOptionData setMinValue(long minValue);
+    CommandOptionData setMinValue(double minValue);
+    CommandOptionData setMaxValue(long maxValue);
+    CommandOptionData setMaxValue(double maxValue);
+    CommandOptionData setRequiredRange(long minValue, long maxValue);
+    CommandOptionData setRequiredRange(double minValue, double maxValue);
     CommandOptionData setMinLength(int minLength);
-    CommandOptionData setMaxLength(Integer maxLength);
+    CommandOptionData setMaxLength(int maxLength);
+    CommandOptionData setRequiredLength(int minLength, int maxLength);
+
+    CommandOptionData addChoice(String name, double value);
+    CommandOptionData addChoice(String name, long value);
+    CommandOptionData addChoice(String name, String value);
+    CommandOptionData addChoices(Command.Choice... choices);
+    CommandOptionData addChoices(Collection<? extends Command.Choice> choices);
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/options/data/GeneralOptionData.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/options/data/GeneralOptionData.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 DWolf Nineteen & The JDA-Extra contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.dwolfnineteen.jdaextra.options.data;
+
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+
+public interface GeneralOptionData {
+    OptionData toGeneralOptionData();
+}

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/options/data/HybridOptionData.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/options/data/HybridOptionData.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2023 DWolf Nineteen & The JDA-Extra contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.dwolfnineteen.jdaextra.options.data;
+
+import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+public class HybridOptionData implements CommandOptionData, GeneralOptionData {
+    // TODO: Maybe replace it with CommandOptionData?
+    private final OptionData slashData;
+
+    public HybridOptionData(@NotNull OptionType type, @NotNull String name, @NotNull String description) {
+        slashData = new OptionData(type, name, description);
+    }
+
+    public HybridOptionData(@NotNull OptionType type,
+                            @NotNull String name,
+                            @NotNull String description,
+                            boolean isRequired) {
+        slashData = new OptionData(type, name, description, isRequired);
+    }
+
+    public HybridOptionData(@NotNull OptionType type,
+                            @NotNull String name,
+                            @NotNull String description,
+                            boolean isRequired,
+                            boolean isAutoComplete) {
+        slashData = new OptionData(type, name, description, isRequired, isAutoComplete);
+    }
+
+    @Override
+    @NotNull
+    public OptionType getType() {
+        return slashData.getType();
+    }
+
+    @Override
+    @NotNull
+    public String getName() {
+        return slashData.getName();
+    }
+
+    @Override
+    @NotNull
+    public String getDescription() {
+        return slashData.getDescription();
+    }
+
+    @Override
+    public boolean isRequired() {
+        return slashData.isRequired();
+    }
+
+    @Override
+    public boolean isAutoComplete() {
+        return slashData.isAutoComplete();
+    }
+
+    @Override
+    @Nullable
+    public Number getMinValue() {
+        return slashData.getMinValue();
+    }
+
+    @Override
+    @Nullable
+    public Number getMaxValue() {
+        return slashData.getMaxValue();
+    }
+
+    @Override
+    @Nullable
+    public Integer getMinLength() {
+        return slashData.getMinLength();
+    }
+
+    @Override
+    @Nullable
+    public Integer getMaxLength() {
+        return slashData.getMaxLength();
+    }
+
+    @Override
+    @NotNull
+    public HybridOptionData setName(@NotNull String name) {
+        slashData.setName(name);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public HybridOptionData setDescription(@NotNull String description) {
+        slashData.setDescription(description);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public HybridOptionData setRequired(boolean required) {
+        slashData.setRequired(required);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public HybridOptionData setAutoComplete(boolean autoComplete) {
+        slashData.setAutoComplete(autoComplete);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public HybridOptionData setMinValue(long minValue) {
+        slashData.setMinValue(minValue);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public HybridOptionData setMinValue(double minValue) {
+        slashData.setMinValue(minValue);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public HybridOptionData setMaxValue(long maxValue) {
+        slashData.setMaxValue(maxValue);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public HybridOptionData setMaxValue(double maxValue) {
+        slashData.setMaxValue(maxValue);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public HybridOptionData setRequiredRange(long minValue, long maxValue) {
+        slashData.setRequiredRange(minValue, maxValue);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public HybridOptionData setRequiredRange(double minValue, double maxValue) {
+        slashData.setRequiredRange(minValue, maxValue);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public HybridOptionData setMinLength(int minLength) {
+        slashData.setMinLength(minLength);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public HybridOptionData setMaxLength(int maxLength) {
+        slashData.setMaxLength(maxLength);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public HybridOptionData setRequiredLength(int minLength, int maxLength) {
+        slashData.setRequiredLength(minLength, maxLength);
+
+        return this;
+    }
+
+    @Override
+    public HybridOptionData addChoice(@NotNull String name, double value) {
+        slashData.addChoice(name, value);
+
+        return this;
+    }
+
+    @Override
+    public HybridOptionData addChoice(@NotNull String name, long value) {
+        slashData.addChoice(name, value);
+
+        return this;
+    }
+
+    @Override
+    public HybridOptionData addChoice(@NotNull String name, @NotNull String value) {
+        slashData.addChoice(name, value);
+
+        return this;
+    }
+
+    @Override
+    public HybridOptionData addChoices(Command.@NotNull Choice... choices) {
+        slashData.addChoices(choices);
+
+        return this;
+    }
+
+    @Override
+    public HybridOptionData addChoices(@NotNull Collection<? extends Command.Choice> choices) {
+        slashData.addChoices(choices);
+
+        return this;
+    }
+
+    @Override
+    public OptionData toGeneralOptionData() {
+        return slashData;
+    }
+}

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/options/data/PrefixOptionData.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/options/data/PrefixOptionData.java
@@ -21,9 +21,12 @@ SOFTWARE.
 */
 package com.dwolfnineteen.jdaextra.options.data;
 
+import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
 
 public class PrefixOptionData implements CommandOptionData {
     private final OptionType type;
@@ -171,7 +174,7 @@ public class PrefixOptionData implements CommandOptionData {
 
     @Override
     @NotNull
-    public PrefixOptionData setMinValue(Number minValue) {
+    public PrefixOptionData setMinValue(long minValue) {
         this.minValue = minValue;
 
         return this;
@@ -179,7 +182,41 @@ public class PrefixOptionData implements CommandOptionData {
 
     @Override
     @NotNull
-    public PrefixOptionData setMaxValue(Number maxValue) {
+    public PrefixOptionData setMinValue(double minValue) {
+        this.minValue= minValue;
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public PrefixOptionData setMaxValue(long maxValue) {
+        this.maxValue = maxValue;
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public PrefixOptionData setMaxValue(double maxValue) {
+        this.maxValue = maxValue;
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public PrefixOptionData setRequiredRange(long minValue, long maxValue) {
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public PrefixOptionData setRequiredRange(double minValue, double maxValue) {
+        this.minValue = minValue;
         this.maxValue = maxValue;
 
         return this;
@@ -195,9 +232,49 @@ public class PrefixOptionData implements CommandOptionData {
 
     @Override
     @NotNull
-    public PrefixOptionData setMaxLength(Integer maxLength) {
+    public PrefixOptionData setMaxLength(int maxLength) {
         this.maxLength = maxLength;
 
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public PrefixOptionData setRequiredLength(int minLength, int maxLength) {
+        this.minLength = minLength;
+        this.maxLength = maxLength;
+
+        return this;
+    }
+
+    // TODO: Support for choices
+    @Override
+    @NotNull
+    public PrefixOptionData addChoice(String name, double value) {
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public PrefixOptionData addChoice(String name, long value) {
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public PrefixOptionData addChoice(String name, String value) {
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public PrefixOptionData addChoices(Command.Choice... choices) {
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public PrefixOptionData addChoices(Collection<? extends Command.Choice> choices) {
         return this;
     }
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/options/data/SlashOptionData.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/options/data/SlashOptionData.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2023 DWolf Nineteen & The JDA-Extra contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.dwolfnineteen.jdaextra.options.data;
+
+import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+public class SlashOptionData extends OptionData implements CommandOptionData {
+    public SlashOptionData(@NotNull OptionType type, @NotNull String name, @NotNull String description) {
+        super(type, name, description);
+    }
+
+    public SlashOptionData(@NotNull OptionType type,
+                           @NotNull String name,
+                           @NotNull String description,
+                           boolean isRequired) {
+        super(type, name, description, isRequired);
+    }
+
+    public SlashOptionData(@NotNull OptionType type,
+                           @NotNull String name,
+                           @NotNull String description,
+                           boolean isRequired,
+                           boolean isAutoComplete) {
+        super(type, name, description, isRequired, isAutoComplete);
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData setName(@NotNull String name) {
+        super.setName(name);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData setDescription(@NotNull String description) {
+        super.setDescription(description);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData setRequired(boolean required) {
+        super.setRequired(required);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData setAutoComplete(boolean autoComplete) {
+        super.setAutoComplete(autoComplete);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData setMinValue(long minValue) {
+        super.setMinValue(minValue);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData setMinValue(double minValue) {
+        super.setMinValue(minValue);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData setMaxValue(long maxValue) {
+        super.setMaxValue(maxValue);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData setMaxValue(double maxValue) {
+        super.setMaxValue(maxValue);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData setRequiredRange(long minValue, long maxValue) {
+        super.setRequiredRange(minValue, maxValue);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData setRequiredRange(double minValue, double maxValue) {
+        super.setRequiredRange(minValue, maxValue);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData setMinLength(int minLength) {
+        super.setMinLength(minLength);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData setMaxLength(int maxLength) {
+        super.setMaxLength(maxLength);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData setRequiredLength(int minLength, int maxLength) {
+        super.setRequiredLength(minLength, maxLength);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData addChoice(@NotNull String name, double value) {
+        super.addChoice(name, value);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData addChoice(@NotNull String name, long value) {
+        super.addChoice(name, value);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData addChoice(@NotNull String name, @NotNull String value) {
+        super.addChoice(name, value);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData addChoices(Command.@NotNull Choice... choices) {
+        super.addChoices(choices);
+
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public SlashOptionData addChoices(@NotNull Collection<? extends Command.Choice> choices) {
+        super.addChoices(choices);
+
+        return this;
+    }
+}


### PR DESCRIPTION
### Changes
- ✅ Internal
- ❌ Interface (affects end-user code)
- ❌ Gradle (wrapper, scripts, dependencies)
- ❌ Docs
- ❌ Metadata (README, copyright, Git files, files in `.github`)
- ❌ Other: ...
### Description
Add custom option data for all commands. This PR is related to #106.
