### PR TITLE
Update project to JDK 21, but leave compile at 8

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -30,10 +30,15 @@ repositories {
 dependencies {
     api("net.dv8tion:JDA:5.0.0-beta.19")
     compileOnly("org.jetbrains:annotations:24.1.0")
+    // TODO: Add JUnit 5 (and some testing...)
 }
 
 java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
+    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(8)
     }
 }


### PR DESCRIPTION
### Changes
- ❌ Internal
- ❌ Interface (affects end-user code)
- ✅ Gradle (wrapper, scripts, dependencies)
- ❌ Docs
- ❌ Metadata (README, copyright, Git files, files in `.github`)
- ❌ Other: ...
### Description
Update project to 21 (javadoc building, etc), but leave compilation and development at Java 8 for backward compatibility.
