### PR TITLE
Remove duplicated code in builders and models (add SlashLikeCommand)

### DIFF
--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/HybridCommandBuilder.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/HybridCommandBuilder.java
@@ -22,10 +22,6 @@
 package com.dwolfnineteen.jdaextra.builders;
 
 import com.dwolfnineteen.jdaextra.annotations.ExtraHybridCommand;
-import com.dwolfnineteen.jdaextra.annotations.commands.CommandLocalizationFunction;
-import com.dwolfnineteen.jdaextra.annotations.commands.DescriptionLocalizations;
-import com.dwolfnineteen.jdaextra.annotations.commands.Localization;
-import com.dwolfnineteen.jdaextra.annotations.commands.NameLocalizations;
 import com.dwolfnineteen.jdaextra.annotations.options.AutoComplete;
 import com.dwolfnineteen.jdaextra.annotations.options.HybridOption;
 import com.dwolfnineteen.jdaextra.annotations.options.Required;
@@ -35,21 +31,17 @@ import com.dwolfnineteen.jdaextra.exceptions.CommandAnnotationNotFoundException;
 import com.dwolfnineteen.jdaextra.models.CommandModel;
 import com.dwolfnineteen.jdaextra.models.HybridCommandModel;
 import com.dwolfnineteen.jdaextra.options.data.HybridOptionData;
-import net.dv8tion.jda.api.interactions.DiscordLocale;
-import net.dv8tion.jda.api.interactions.commands.localization.ResourceBundleLocalizationFunction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Hybrid command builder.
  */
-public class HybridCommandBuilder extends CommandBuilder {
+public class HybridCommandBuilder extends SlashLikeCommandBuilder {
     /**
      * Construct new {@link HybridCommandBuilder}.
      *
@@ -110,31 +102,6 @@ public class HybridCommandBuilder extends CommandBuilder {
     @Override
     @NotNull
     protected HybridCommandModel buildSettings(@NotNull CommandModel model, @NotNull Class<? extends BaseCommand> cls) {
-        Map<DiscordLocale, String> nameLocalizations = new HashMap<>();
-        Map<DiscordLocale, String> descriptionLocalizations = new HashMap<>();
-
-        NameLocalizations nameLocalizationsAnnotation = cls.getAnnotation(NameLocalizations.class);
-        DescriptionLocalizations descriptionLocalizationsAnnotation = cls.getAnnotation(DescriptionLocalizations.class);
-        CommandLocalizationFunction localizationFunctionAnnotation = cls.getAnnotation(CommandLocalizationFunction.class);
-
-        if (nameLocalizationsAnnotation != null) {
-            for (Localization localization : nameLocalizationsAnnotation.value()) {
-                nameLocalizations.put(localization.locale(), localization.string());
-            }
-        }
-
-        if (descriptionLocalizationsAnnotation != null) {
-            for (Localization localization : descriptionLocalizationsAnnotation.value()) {
-                descriptionLocalizations.put(localization.locale(), localization.string());
-            }
-        }
-
-        return ((HybridCommandModel) super.buildSettings(model, cls))
-                .setNameLocalizations(nameLocalizations)
-                .setDescriptionLocalizations(descriptionLocalizations)
-                .setLocalizationFunction(localizationFunctionAnnotation == null
-                        ? ResourceBundleLocalizationFunction.empty().build()
-                        : ResourceBundleLocalizationFunction.fromBundles(localizationFunctionAnnotation.baseName(),
-                        localizationFunctionAnnotation.locales()).build());
+        return (HybridCommandModel) super.buildSettings(model, cls);
     }
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/SlashCommandBuilder.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/SlashCommandBuilder.java
@@ -22,10 +22,6 @@
 package com.dwolfnineteen.jdaextra.builders;
 
 import com.dwolfnineteen.jdaextra.annotations.ExtraSlashCommand;
-import com.dwolfnineteen.jdaextra.annotations.commands.CommandLocalizationFunction;
-import com.dwolfnineteen.jdaextra.annotations.commands.DescriptionLocalizations;
-import com.dwolfnineteen.jdaextra.annotations.commands.Localization;
-import com.dwolfnineteen.jdaextra.annotations.commands.NameLocalizations;
 import com.dwolfnineteen.jdaextra.annotations.options.AutoComplete;
 import com.dwolfnineteen.jdaextra.annotations.options.Required;
 import com.dwolfnineteen.jdaextra.annotations.options.SlashOption;
@@ -36,22 +32,18 @@ import com.dwolfnineteen.jdaextra.models.CommandModel;
 import com.dwolfnineteen.jdaextra.models.SlashCommandModel;
 import com.dwolfnineteen.jdaextra.options.data.SlashOptionData;
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.interactions.DiscordLocale;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
-import net.dv8tion.jda.api.interactions.commands.localization.ResourceBundleLocalizationFunction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Slash command builder.
  */
-public class SlashCommandBuilder extends CommandBuilder {
+public class SlashCommandBuilder extends SlashLikeCommandBuilder {
     /**
      * Construct new {@link SlashCommandBuilder}.
      *
@@ -120,31 +112,6 @@ public class SlashCommandBuilder extends CommandBuilder {
     @Override
     @NotNull
     protected SlashCommandModel buildSettings(@NotNull CommandModel model, @NotNull Class<? extends BaseCommand> cls) {
-        Map<DiscordLocale, String> nameLocalizations = new HashMap<>();
-        Map<DiscordLocale, String> descriptionLocalizations = new HashMap<>();
-
-        NameLocalizations nameLocalizationsAnnotation = cls.getAnnotation(NameLocalizations.class);
-        DescriptionLocalizations descriptionLocalizationsAnnotation = cls.getAnnotation(DescriptionLocalizations.class);
-        CommandLocalizationFunction localizationFunctionAnnotation = cls.getAnnotation(CommandLocalizationFunction.class);
-
-        if (nameLocalizationsAnnotation != null) {
-            for (Localization localization : nameLocalizationsAnnotation.value()) {
-                nameLocalizations.put(localization.locale(), localization.string());
-            }
-        }
-
-        if (descriptionLocalizationsAnnotation != null) {
-            for (Localization localization : descriptionLocalizationsAnnotation.value()) {
-                descriptionLocalizations.put(localization.locale(), localization.string());
-            }
-        }
-
-        return ((SlashCommandModel) super.buildSettings(model, cls))
-                .setNameLocalizations(nameLocalizations)
-                .setDescriptionLocalizations(descriptionLocalizations)
-                .setLocalizationFunction(localizationFunctionAnnotation == null
-                        ? ResourceBundleLocalizationFunction.empty().build()
-                        : ResourceBundleLocalizationFunction.fromBundles(localizationFunctionAnnotation.baseName(),
-                        localizationFunctionAnnotation.locales()).build());
+        return (SlashCommandModel) super.buildSettings(model, cls);
     }
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/SlashLikeCommandBuilder.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/builders/SlashLikeCommandBuilder.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023 DWolf Nineteen & The JDA-Extra contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.dwolfnineteen.jdaextra.builders;
+
+import com.dwolfnineteen.jdaextra.annotations.commands.CommandLocalizationFunction;
+import com.dwolfnineteen.jdaextra.annotations.commands.DescriptionLocalizations;
+import com.dwolfnineteen.jdaextra.annotations.commands.Localization;
+import com.dwolfnineteen.jdaextra.annotations.commands.NameLocalizations;
+import com.dwolfnineteen.jdaextra.commands.BaseCommand;
+import com.dwolfnineteen.jdaextra.models.CommandModel;
+import com.dwolfnineteen.jdaextra.models.SlashLikeCommandModel;
+import net.dv8tion.jda.api.interactions.DiscordLocale;
+import net.dv8tion.jda.api.interactions.commands.localization.ResourceBundleLocalizationFunction;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Base builder for commands that can be executed as a slash (regular slash/hybrid).
+ */
+public abstract class SlashLikeCommandBuilder extends CommandBuilder {
+    /**
+     * Build command settings (such as {@link com.dwolfnineteen.jdaextra.annotations.commands.GuildOnly @GuildOnly}).
+     *
+     * @param model The command model.
+     * @param cls The command class.
+     * @return Configured {@link SlashLikeCommandModel}.
+     */
+    @Override
+    @NotNull
+    protected SlashLikeCommandModel buildSettings(@NotNull CommandModel model, @NotNull Class<? extends BaseCommand> cls) {
+        Map<DiscordLocale, String> nameLocalizations = new HashMap<>();
+        Map<DiscordLocale, String> descriptionLocalizations = new HashMap<>();
+
+        NameLocalizations nameLocalizationsAnnotation = cls.getAnnotation(NameLocalizations.class);
+        DescriptionLocalizations descriptionLocalizationsAnnotation = cls.getAnnotation(DescriptionLocalizations.class);
+        CommandLocalizationFunction localizationFunctionAnnotation = cls.getAnnotation(CommandLocalizationFunction.class);
+
+        if (nameLocalizationsAnnotation != null) {
+            for (Localization localization : nameLocalizationsAnnotation.value()) {
+                nameLocalizations.put(localization.locale(), localization.string());
+            }
+        }
+
+        if (descriptionLocalizationsAnnotation != null) {
+            for (Localization localization : descriptionLocalizationsAnnotation.value()) {
+                descriptionLocalizations.put(localization.locale(), localization.string());
+            }
+        }
+
+        return ((SlashLikeCommandModel) super.buildSettings(model, cls))
+                .setNameLocalizations(nameLocalizations)
+                .setDescriptionLocalizations(descriptionLocalizations)
+                .setLocalizationFunction(localizationFunctionAnnotation == null
+                        ? ResourceBundleLocalizationFunction.empty().build()
+                        : ResourceBundleLocalizationFunction.fromBundles(localizationFunctionAnnotation.baseName(),
+                        localizationFunctionAnnotation.locales()).build());
+    }
+}

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/BaseCommand.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/BaseCommand.java
@@ -22,7 +22,10 @@
 package com.dwolfnineteen.jdaextra.commands;
 
 /**
- * Empty abstract class for basic commands (prefix/slash/hybrid).
+ * Empty abstract class for regular commands (prefix/slash/hybrid).
+ * <br>
+ * This is necessary for grouping command classes
+ * and convenient work with them inside the framework.
  */
 public abstract class BaseCommand {
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/HybridCommand.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/HybridCommand.java
@@ -21,9 +21,10 @@
  */
 package com.dwolfnineteen.jdaextra.commands;
 
-// TODO: Remove extends SlashCommand
 /**
  * Empty abstract class for hybrid commands.
+ *
+ * @see BaseCommand
  */
-public abstract class HybridCommand extends SlashCommand {
+public abstract class HybridCommand extends SlashLikeCommand {
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/SlashCommand.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/SlashCommand.java
@@ -23,6 +23,8 @@ package com.dwolfnineteen.jdaextra.commands;
 
 /**
  * Empty abstract class for slash commands.
+ *
+ * @see BaseCommand
  */
-public abstract class SlashCommand extends BaseCommand {
+public abstract class SlashCommand extends SlashLikeCommand {
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/SlashLikeCommand.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/commands/SlashLikeCommand.java
@@ -22,9 +22,9 @@
 package com.dwolfnineteen.jdaextra.commands;
 
 /**
- * Empty abstract class for prefix commands.
+ * Empty abstract class for commands that can be executed as a slash (regular slash/hybrid).
  *
  * @see BaseCommand
  */
-public abstract class PrefixCommand extends BaseCommand {
+public abstract class SlashLikeCommand extends BaseCommand {
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/models/HybridCommandModel.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/models/HybridCommandModel.java
@@ -36,8 +36,6 @@ import java.util.Map;
  */
 public class HybridCommandModel extends SlashLikeCommandModel {
     private String description;
-    private Map<DiscordLocale, String> descriptionLocalizations;
-    private LocalizationFunction localizationFunction;
     private List<HybridOptionData> options;
 
     /**
@@ -58,26 +56,6 @@ public class HybridCommandModel extends SlashLikeCommandModel {
     @NotNull
     public String getDescription() {
         return description;
-    }
-
-    /**
-     * Multiple localizations of the command description.
-     *
-     * @return {@link Map} of {@link DiscordLocale} and description on different languages.
-     */
-    @NotNull
-    public Map<DiscordLocale, String> getDescriptionLocalizations() {
-        return descriptionLocalizations;
-    }
-
-    /**
-     * The {@link LocalizationFunction} for this command.
-     *
-     * @return The {@link LocalizationFunction}.
-     */
-    @NotNull
-    public LocalizationFunction getLocalizationFunction() {
-        return localizationFunction;
     }
 
     /**

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/models/HybridCommandModel.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/models/HybridCommandModel.java
@@ -39,16 +39,6 @@ public class HybridCommandModel extends SlashLikeCommandModel {
     private List<HybridOptionData> options;
 
     /**
-     * Multiple localizations of the command name.
-     *
-     * @return {@link Map} of {@link DiscordLocale} and name on different languages.
-     */
-    @NotNull
-    public Map<DiscordLocale, String> getNameLocalizations() {
-        return nameLocalizations;
-    }
-
-    /**
      * The command description.
      *
      * @return The description.

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/models/SlashCommandModel.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/models/SlashCommandModel.java
@@ -36,8 +36,6 @@ import java.util.Map;
  */
 public class SlashCommandModel extends SlashLikeCommandModel {
     private String description;
-    private Map<DiscordLocale, String> descriptionLocalizations;
-    private LocalizationFunction localizationFunction;
     private List<SlashOptionData> options;
 
     /**
@@ -58,26 +56,6 @@ public class SlashCommandModel extends SlashLikeCommandModel {
     @NotNull
     public String getDescription() {
         return description;
-    }
-
-    /**
-     * Multiple localizations of the command description.
-     *
-     * @return {@link Map} of {@link DiscordLocale} and description on different languages.
-     */
-    @NotNull
-    public Map<DiscordLocale, String> getDescriptionLocalizations() {
-        return descriptionLocalizations;
-    }
-
-    /**
-     * The {@link LocalizationFunction} for this command.
-     *
-     * @return The {@link LocalizationFunction}.
-     */
-    @NotNull
-    public LocalizationFunction getLocalizationFunction() {
-        return localizationFunction;
     }
 
     /**

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/models/SlashCommandModel.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/models/SlashCommandModel.java
@@ -31,10 +31,10 @@ import java.util.Map;
 
 /**
  * Slash command model.
+ *
  * @see CommandModel
  */
-public class SlashCommandModel extends CommandModel {
-    private Map<DiscordLocale, String> nameLocalizations;
+public class SlashCommandModel extends SlashLikeCommandModel {
     private String description;
     private Map<DiscordLocale, String> descriptionLocalizations;
     private LocalizationFunction localizationFunction;
@@ -96,6 +96,7 @@ public class SlashCommandModel extends CommandModel {
      * @param nameLocalizations {@link Map} of {@link DiscordLocale} and name on different languages.
      * @return The {@link SlashCommandModel} instance, for chaining.
      */
+    @Override
     @NotNull
     public SlashCommandModel setNameLocalizations(@NotNull Map<DiscordLocale, String> nameLocalizations) {
         this.nameLocalizations = nameLocalizations;
@@ -122,6 +123,7 @@ public class SlashCommandModel extends CommandModel {
      * @param descriptionLocalizations {@link Map} of {@link DiscordLocale} and description on different languages.
      * @return The {@link SlashCommandModel} instance, for chaining.
      */
+    @Override
     @NotNull
     public SlashCommandModel setDescriptionLocalizations(@NotNull Map<DiscordLocale, String> descriptionLocalizations) {
         this.descriptionLocalizations = descriptionLocalizations;
@@ -139,6 +141,7 @@ public class SlashCommandModel extends CommandModel {
      * @param localizationFunction The {@link LocalizationFunction}.
      * @return The {@link SlashCommandModel} instance, for chaining.
      */
+    @Override
     @NotNull
     public SlashCommandModel setLocalizationFunction(@NotNull LocalizationFunction localizationFunction) {
         this.localizationFunction = localizationFunction;

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/models/SlashCommandModel.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/models/SlashCommandModel.java
@@ -39,16 +39,6 @@ public class SlashCommandModel extends SlashLikeCommandModel {
     private List<SlashOptionData> options;
 
     /**
-     * Multiple localizations of the command name.
-     *
-     * @return {@link Map} of {@link DiscordLocale} and name on different languages.
-     */
-    @NotNull
-    public Map<DiscordLocale, String> getNameLocalizations() {
-        return nameLocalizations;
-    }
-
-    /**
      * The command description.
      *
      * @return The description.

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/models/SlashLikeCommandModel.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/models/SlashLikeCommandModel.java
@@ -21,24 +21,19 @@
  */
 package com.dwolfnineteen.jdaextra.models;
 
-import com.dwolfnineteen.jdaextra.options.data.HybridOptionData;
 import net.dv8tion.jda.api.interactions.DiscordLocale;
 import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFunction;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
 import java.util.Map;
 
 /**
- * Hybrid command model.
- *
- * @see CommandModel
+ * Base command model for commands that can be executed as a slash (regular slash/hybrid).
  */
-public class HybridCommandModel extends SlashLikeCommandModel {
-    private String description;
-    private Map<DiscordLocale, String> descriptionLocalizations;
-    private LocalizationFunction localizationFunction;
-    private List<HybridOptionData> options;
+public abstract class SlashLikeCommandModel extends CommandModel {
+    protected Map<DiscordLocale, String> nameLocalizations;
+    protected Map<DiscordLocale, String> descriptionLocalizations;
+    protected LocalizationFunction localizationFunction;
 
     /**
      * Multiple localizations of the command name.
@@ -48,16 +43,6 @@ public class HybridCommandModel extends SlashLikeCommandModel {
     @NotNull
     public Map<DiscordLocale, String> getNameLocalizations() {
         return nameLocalizations;
-    }
-
-    /**
-     * The command description.
-     *
-     * @return The description.
-     */
-    @NotNull
-    public String getDescription() {
-        return description;
     }
 
     /**
@@ -81,56 +66,20 @@ public class HybridCommandModel extends SlashLikeCommandModel {
     }
 
     /**
-     * All command options as a {@link List}.
-     *
-     * @return The command options.
-     */
-    @NotNull
-    public List<HybridOptionData> getOptions() {
-        return options;
-    }
-
-    /**
      * Sets multiple localizations of the command name.
      *
      * @param nameLocalizations {@link Map} of {@link DiscordLocale} and name on different languages.
-     * @return The {@link HybridCommandModel} instance, for chaining.
+     * @return The {@link SlashLikeCommandModel} instance, for chaining.
      */
-    @Override
-    @NotNull
-    public HybridCommandModel setNameLocalizations(@NotNull Map<DiscordLocale, String> nameLocalizations) {
-        this.nameLocalizations = nameLocalizations;
-
-        return this;
-    }
-
-    /**
-     * Sets the command description.
-     *
-     * @param description The command description.
-     * @return Current {@link HybridCommandModel} instance,
-     * for chaining.
-     */
-    @NotNull
-    public HybridCommandModel setDescription(@NotNull String description) {
-        this.description = description;
-
-        return this;
-    }
+    public abstract SlashLikeCommandModel setNameLocalizations(Map<DiscordLocale, String> nameLocalizations);
 
     /**
      * Sets multiple localizations of the command description.
      *
      * @param descriptionLocalizations {@link Map} of {@link DiscordLocale} and description on different languages.
-     * @return The {@link HybridCommandModel} instance, for chaining.
+     * @return The {@link SlashLikeCommandModel} instance, for chaining.
      */
-    @Override
-    @NotNull
-    public HybridCommandModel setDescriptionLocalizations(@NotNull Map<DiscordLocale, String> descriptionLocalizations) {
-        this.descriptionLocalizations = descriptionLocalizations;
-
-        return this;
-    }
+    public abstract SlashLikeCommandModel setDescriptionLocalizations(Map<DiscordLocale, String> descriptionLocalizations);
 
     /**
      * Sets the {@link LocalizationFunction} for this command.
@@ -140,28 +89,7 @@ public class HybridCommandModel extends SlashLikeCommandModel {
      * {@link net.dv8tion.jda.api.interactions.commands.localization.ResourceBundleLocalizationFunction ResourceBundleLocalizationFunction}.
      *
      * @param localizationFunction The {@link LocalizationFunction}.
-     * @return The {@link HybridCommandModel} instance, for chaining.
+     * @return The {@link SlashLikeCommandModel} instance, for chaining.
      */
-    @Override
-    @NotNull
-    public HybridCommandModel setLocalizationFunction(@NotNull LocalizationFunction localizationFunction) {
-        this.localizationFunction = localizationFunction;
-
-        return this;
-    }
-
-    // TODO: Add addOptions()
-    /**
-     * Sets the command options as a {@link List}.
-     *
-     * @param options The command options.
-     * @return Current {@link HybridCommandModel} instance,
-     * for chaining.
-     */
-    @NotNull
-    public HybridCommandModel setOptions(@NotNull List<HybridOptionData> options) {
-        this.options = options;
-
-        return this;
-    }
+    public abstract SlashLikeCommandModel setLocalizationFunction(LocalizationFunction localizationFunction);
 }


### PR DESCRIPTION
### Changes
- ✅ Internal
- ❌ Interface (affects end-user code)
- ❌ Gradle (wrapper, scripts, dependencies)
- ❌ Docs
- ❌ Metadata (README, copyright, Git files, files in `.github`)
- ❌ Other: ...
### Description
Remove duplicated code in builders and models by adding `SlashLikeCommand` - new abstract class for commands that can be executed as a slash. This allows to take out code to `SlashLikeCommand` that is common to slash and hybrid commands.
