### PR TITLE
Move setters implementation to inherited classes (CommandModel)

### DIFF
--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/models/CommandModel.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/models/CommandModel.java
@@ -32,20 +32,33 @@ import java.lang.reflect.Method;
  * and created for better command classes representation.
  */
 public abstract class CommandModel {
-    // TODO: private List<CommandOptionData> options
-    private BaseCommand command;
-    private Method main;
-    private String name;
-    private boolean guildOnly;
-    private boolean nsfw;
+    /**
+     * The command class inherited from one of the {@link com.dwolfnineteen.jdaextra.commands commands}.
+     */
+    protected BaseCommand command;
+    /**
+     * The command <strong>main</strong> entry point.
+     */
+    protected Method main;
+    /**
+     * The command name.
+     */
+    protected String name;
+    /**
+     * Whether this command can be executed only on guilds.
+     */
+    protected boolean guildOnly;
+    /**
+     * Whether this command can be executed only in NSFW channels.
+     */
+    protected boolean nsfw;
 
     /**
      * The command class inherited from one of the {@link com.dwolfnineteen.jdaextra.commands commands}.
      *
      * @return The command class.
      */
-    @NotNull
-    public BaseCommand getCommand() {
+    public @NotNull BaseCommand getCommand() {
         return command;
     }
 
@@ -72,8 +85,7 @@ public abstract class CommandModel {
      * @return The entry point. {@code null} if the command doesn't have a main entry point.
      * @see com.dwolfnineteen.jdaextra.annotations.ExtraMainCommand ExtraMainCommand
      */
-    @Nullable
-    public Method getMain() {
+    public @Nullable Method getMain() {
         return main;
     }
 
@@ -82,8 +94,7 @@ public abstract class CommandModel {
      *
      * @return The name.
      */
-    @NotNull
-    public String getName() {
+    public @NotNull String getName() {
         return name;
     }
 
@@ -105,71 +116,39 @@ public abstract class CommandModel {
         return nsfw;
     }
 
-    // TODO: Move setters to inherited classes and return (Slash/Prefix/Hybrid)CommandModel
-
     /**
      * Sets the command class inherited from one of the {@link com.dwolfnineteen.jdaextra.commands commands}.
      *
      * @param command The command class.
-     * @return The {@link com.dwolfnineteen.jdaextra.models.CommandModel CommandModel} instance, for chaining.
      */
-    @NotNull
-    public CommandModel setCommand(@NotNull BaseCommand command) {
-        this.command = command;
-
-        return this;
-    }
+    public abstract CommandModel setCommand(BaseCommand command);
 
     /**
      * Sets the command <strong>main</strong> entry point.
      *
      * @param main The command entry point.
-     * @return The {@link com.dwolfnineteen.jdaextra.models.CommandModel CommandModel} instance, for chaining.
      * @see #getMain() getMain()
      */
-    @NotNull
-    public CommandModel setMain(@NotNull Method main) {
-        this.main = main;
-
-        return this;
-    }
+    public abstract CommandModel setMain(Method main);
 
     /**
      * Sets the command name.
      *
      * @param name The name.
-     * @return The {@link com.dwolfnineteen.jdaextra.models.CommandModel CommandModel} instance, for chaining.
      */
-    @NotNull
-    public CommandModel setName(@NotNull String name) {
-        this.name = name;
-
-        return this;
-    }
+    public abstract CommandModel setName(String name);
 
     /**
      * Whether this command can be executed only on guilds.
      *
      * @param guildOnly Whether this command is guild only.
-     * @return The {@link com.dwolfnineteen.jdaextra.models.CommandModel CommandModel} instance, for chaining.
      */
-    @NotNull
-    public CommandModel setGuildOnly(boolean guildOnly) {
-        this.guildOnly = guildOnly;
-
-        return this;
-    }
+    public abstract CommandModel setGuildOnly(boolean guildOnly);
 
     /**
      * Whether this command can be executed only in NSFW channels.
      *
      * @param nsfw Whether this command is NSFW only.
-     * @return The {@link com.dwolfnineteen.jdaextra.models.CommandModel CommandModel} instance, for chaining.
      */
-    @NotNull
-    public CommandModel setNSFW(boolean nsfw) {
-        this.nsfw = nsfw;
-
-        return this;
-    }
+    public abstract CommandModel setNSFW(boolean nsfw);
 }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/models/HybridCommandModel.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/models/HybridCommandModel.java
@@ -21,11 +21,14 @@
  */
 package com.dwolfnineteen.jdaextra.models;
 
+import com.dwolfnineteen.jdaextra.commands.BaseCommand;
 import com.dwolfnineteen.jdaextra.options.data.HybridOptionData;
 import net.dv8tion.jda.api.interactions.DiscordLocale;
 import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFunction;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 
@@ -43,8 +46,7 @@ public class HybridCommandModel extends SlashLikeCommandModel {
      *
      * @return The description.
      */
-    @NotNull
-    public String getDescription() {
+    public @NotNull String getDescription() {
         return description;
     }
 
@@ -53,20 +55,18 @@ public class HybridCommandModel extends SlashLikeCommandModel {
      *
      * @return The command options.
      */
-    @NotNull
-    public List<HybridOptionData> getOptions() {
+    public @NotNull List<HybridOptionData> getOptions() {
         return options;
     }
 
     /**
-     * Sets multiple localizations of the command name.
+     * {@inheritDoc}
      *
-     * @param nameLocalizations {@link Map} of {@link DiscordLocale} and name on different languages.
+     * @param nameLocalizations {@inheritDoc}
      * @return The {@link HybridCommandModel} instance, for chaining.
      */
     @Override
-    @NotNull
-    public HybridCommandModel setNameLocalizations(@NotNull Map<DiscordLocale, String> nameLocalizations) {
+    public @NotNull HybridCommandModel setNameLocalizations(@NotNull Map<DiscordLocale, String> nameLocalizations) {
         this.nameLocalizations = nameLocalizations;
 
         return this;
@@ -76,43 +76,35 @@ public class HybridCommandModel extends SlashLikeCommandModel {
      * Sets the command description.
      *
      * @param description The command description.
-     * @return Current {@link HybridCommandModel} instance,
-     * for chaining.
+     * @return The {@link HybridCommandModel} instance, for chaining.
      */
-    @NotNull
-    public HybridCommandModel setDescription(@NotNull String description) {
+    public @NotNull HybridCommandModel setDescription(@NotNull String description) {
         this.description = description;
 
         return this;
     }
 
     /**
-     * Sets multiple localizations of the command description.
+     * {@inheritDoc}
      *
-     * @param descriptionLocalizations {@link Map} of {@link DiscordLocale} and description on different languages.
+     * @param descriptionLocalizations {@inheritDoc}
      * @return The {@link HybridCommandModel} instance, for chaining.
      */
     @Override
-    @NotNull
-    public HybridCommandModel setDescriptionLocalizations(@NotNull Map<DiscordLocale, String> descriptionLocalizations) {
+    public @NotNull HybridCommandModel setDescriptionLocalizations(@NotNull Map<DiscordLocale, String> descriptionLocalizations) {
         this.descriptionLocalizations = descriptionLocalizations;
 
         return this;
     }
 
     /**
-     * Sets the {@link LocalizationFunction} for this command.
-     * This allows to localize the entire command.
-     * <br>
-     * Only accepts
-     * {@link net.dv8tion.jda.api.interactions.commands.localization.ResourceBundleLocalizationFunction ResourceBundleLocalizationFunction}.
+     * {@inheritDoc}
      *
-     * @param localizationFunction The {@link LocalizationFunction}.
+     * @param localizationFunction {@inheritDoc}
      * @return The {@link HybridCommandModel} instance, for chaining.
      */
     @Override
-    @NotNull
-    public HybridCommandModel setLocalizationFunction(@NotNull LocalizationFunction localizationFunction) {
+    public @NotNull HybridCommandModel setLocalizationFunction(@NotNull LocalizationFunction localizationFunction) {
         this.localizationFunction = localizationFunction;
 
         return this;
@@ -123,12 +115,76 @@ public class HybridCommandModel extends SlashLikeCommandModel {
      * Sets the command options as a {@link List}.
      *
      * @param options The command options.
-     * @return Current {@link HybridCommandModel} instance,
-     * for chaining.
+     * @return The {@link HybridCommandModel} instance, for chaining.
      */
-    @NotNull
-    public HybridCommandModel setOptions(@NotNull List<HybridOptionData> options) {
+    public @NotNull HybridCommandModel setOptions(@NotNull List<HybridOptionData> options) {
         this.options = options;
+
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param command {@inheritDoc}
+     * @return The {@link HybridCommandModel} instance, for chaining.
+     */
+    @Override
+    public @NotNull HybridCommandModel setCommand(@NotNull BaseCommand command) {
+        this.command = command;
+
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param main {@inheritDoc}
+     * @return The {@link HybridCommandModel} instance, for chaining.
+     * @see #getMain() getMain()
+     */
+    @Override
+    public @NotNull HybridCommandModel setMain(@Nullable Method main) {
+        this.main = main;
+
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param name {@inheritDoc}
+     * @return The {@link HybridCommandModel} instance, for chaining.
+     */
+    @Override
+    public @NotNull HybridCommandModel setName(@NotNull String name) {
+        this.name = name;
+
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param guildOnly {@inheritDoc}
+     * @return The {@link HybridCommandModel} instance, for chaining.
+     */
+    @Override
+    public @NotNull HybridCommandModel setGuildOnly(boolean guildOnly) {
+        this.guildOnly = guildOnly;
+
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param nsfw {@inheritDoc}
+     * @return The {@link HybridCommandModel} instance, for chaining.
+     */
+    @Override
+    public @NotNull HybridCommandModel setNSFW(boolean nsfw) {
+        this.nsfw = nsfw;
 
         return this;
     }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/models/PrefixCommandModel.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/models/PrefixCommandModel.java
@@ -21,14 +21,17 @@
  */
 package com.dwolfnineteen.jdaextra.models;
 
+import com.dwolfnineteen.jdaextra.commands.BaseCommand;
 import com.dwolfnineteen.jdaextra.options.data.PrefixOptionData;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.Method;
 import java.util.List;
 
 /**
  * Prefix command model.
+ *
  * @see com.dwolfnineteen.jdaextra.models.CommandModel CommandModel
  */
 public class PrefixCommandModel extends CommandModel {
@@ -40,8 +43,7 @@ public class PrefixCommandModel extends CommandModel {
      *
      * @return The description. {@code null}, if description not specified.
      */
-    @Nullable
-    public String getDescription() {
+    public @Nullable String getDescription() {
         return description;
     }
 
@@ -50,8 +52,7 @@ public class PrefixCommandModel extends CommandModel {
      *
      * @return The command options.
      */
-    @NotNull
-    public List<PrefixOptionData> getOptions() {
+    public @NotNull List<PrefixOptionData> getOptions() {
         return options;
     }
 
@@ -59,26 +60,88 @@ public class PrefixCommandModel extends CommandModel {
      * Sets the command description.
      *
      * @param description The command description.
-     * @return Current {@link com.dwolfnineteen.jdaextra.models.PrefixCommandModel PrefixCommandModel} instance,
-     * for chaining.
+     * @return The {@link PrefixCommandModel} instance, for chaining.
      */
-    @NotNull
-    public PrefixCommandModel setDescription(@Nullable String description) {
+    public @NotNull PrefixCommandModel setDescription(@Nullable String description) {
         this.description = description;
 
         return this;
     }
 
     /**
-     * Sets the command options as a {@link java.util.List List}.
+     * Sets the command options as a {@link List}.
      *
      * @param options The command options.
-     * @return Current {@link com.dwolfnineteen.jdaextra.models.PrefixCommandModel PrefixCommandModel} instance,
-     * for chaining.
+     * @return The {@link PrefixCommandModel} instance, for chaining.
      */
-    @NotNull
-    public PrefixCommandModel setOptions(@NotNull List<PrefixOptionData> options) {
+    public @NotNull PrefixCommandModel setOptions(@NotNull List<PrefixOptionData> options) {
         this.options = options;
+
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param command {@inheritDoc}
+     * @return The {@link PrefixCommandModel} instance, for chaining.
+     */
+    @Override
+    public @NotNull PrefixCommandModel setCommand(@NotNull BaseCommand command) {
+        this.command = command;
+
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param main {@inheritDoc}
+     * @return The {@link PrefixCommandModel} instance, for chaining.
+     * @see #getMain() getMain()
+     */
+    @Override
+    public @NotNull PrefixCommandModel setMain(@Nullable Method main) {
+        this.main = main;
+
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param name {@inheritDoc}
+     * @return The {@link PrefixCommandModel} instance, for chaining.
+     */
+    @Override
+    public @NotNull PrefixCommandModel setName(@NotNull String name) {
+        this.name = name;
+
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param guildOnly {@inheritDoc}
+     * @return The {@link PrefixCommandModel} instance, for chaining.
+     */
+    @Override
+    public @NotNull PrefixCommandModel setGuildOnly(boolean guildOnly) {
+        this.guildOnly = guildOnly;
+
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param nsfw {@inheritDoc}
+     * @return The {@link PrefixCommandModel} instance, for chaining.
+     */
+    @Override
+    public @NotNull PrefixCommandModel setNSFW(boolean nsfw) {
+        this.nsfw = nsfw;
 
         return this;
     }

--- a/lib/src/main/java/com/dwolfnineteen/jdaextra/models/SlashCommandModel.java
+++ b/lib/src/main/java/com/dwolfnineteen/jdaextra/models/SlashCommandModel.java
@@ -21,11 +21,18 @@
  */
 package com.dwolfnineteen.jdaextra.models;
 
+import com.dwolfnineteen.jdaextra.commands.BaseCommand;
 import com.dwolfnineteen.jdaextra.options.data.SlashOptionData;
 import net.dv8tion.jda.api.interactions.DiscordLocale;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandGroupData;
 import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFunction;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -43,8 +50,7 @@ public class SlashCommandModel extends SlashLikeCommandModel {
      *
      * @return The description.
      */
-    @NotNull
-    public String getDescription() {
+    public @NotNull String getDescription() {
         return description;
     }
 
@@ -53,20 +59,18 @@ public class SlashCommandModel extends SlashLikeCommandModel {
      *
      * @return The command options.
      */
-    @NotNull
-    public List<SlashOptionData> getOptions() {
+    public @NotNull List<SlashOptionData> getOptions() {
         return options;
     }
 
     /**
-     * Sets multiple localizations of the command name.
+     * {@inheritDoc}
      *
-     * @param nameLocalizations {@link Map} of {@link DiscordLocale} and name on different languages.
+     * @param nameLocalizations {@inheritDoc}
      * @return The {@link SlashCommandModel} instance, for chaining.
      */
     @Override
-    @NotNull
-    public SlashCommandModel setNameLocalizations(@NotNull Map<DiscordLocale, String> nameLocalizations) {
+    public @NotNull SlashCommandModel setNameLocalizations(@NotNull Map<DiscordLocale, String> nameLocalizations) {
         this.nameLocalizations = nameLocalizations;
 
         return this;
@@ -76,42 +80,35 @@ public class SlashCommandModel extends SlashLikeCommandModel {
      * Sets the command description.
      *
      * @param description The command description.
-     * @return Current {@link SlashCommandModel} instance, for chaining.
+     * @return The {@link SlashCommandModel} instance, for chaining.
      */
-    @NotNull
-    public SlashCommandModel setDescription(@NotNull String description) {
+    public @NotNull SlashCommandModel setDescription(@NotNull String description) {
         this.description = description;
 
         return this;
     }
 
     /**
-     * Sets multiple localizations of the command description.
+     * {@inheritDoc}
      *
-     * @param descriptionLocalizations {@link Map} of {@link DiscordLocale} and description on different languages.
+     * @param descriptionLocalizations {@inheritDoc}
      * @return The {@link SlashCommandModel} instance, for chaining.
      */
     @Override
-    @NotNull
-    public SlashCommandModel setDescriptionLocalizations(@NotNull Map<DiscordLocale, String> descriptionLocalizations) {
+    public @NotNull SlashCommandModel setDescriptionLocalizations(@NotNull Map<DiscordLocale, String> descriptionLocalizations) {
         this.descriptionLocalizations = descriptionLocalizations;
 
         return this;
     }
 
     /**
-     * Sets the {@link LocalizationFunction} for this command.
-     * This allows to localize the entire command.
-     * <br>
-     * Only accepts
-     * {@link net.dv8tion.jda.api.interactions.commands.localization.ResourceBundleLocalizationFunction ResourceBundleLocalizationFunction}.
+     * {@inheritDoc}
      *
-     * @param localizationFunction The {@link LocalizationFunction}.
+     * @param localizationFunction {@inheritDoc}
      * @return The {@link SlashCommandModel} instance, for chaining.
      */
     @Override
-    @NotNull
-    public SlashCommandModel setLocalizationFunction(@NotNull LocalizationFunction localizationFunction) {
+    public @NotNull SlashCommandModel setLocalizationFunction(@NotNull LocalizationFunction localizationFunction) {
         this.localizationFunction = localizationFunction;
 
         return this;
@@ -123,9 +120,74 @@ public class SlashCommandModel extends SlashLikeCommandModel {
      * @param options The command options.
      * @return Current {@link SlashCommandModel} instance, for chaining.
      */
-    @NotNull
-    public SlashCommandModel setOptions(@NotNull List<SlashOptionData> options) {
+    public @NotNull SlashCommandModel setOptions(@NotNull List<SlashOptionData> options) {
         this.options = options;
+
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param command {@inheritDoc}
+     * @return The {@link SlashCommandModel} instance, for chaining.
+     */
+    @Override
+    public @NotNull SlashCommandModel setCommand(@NotNull BaseCommand command) {
+        this.command = command;
+
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param main {@inheritDoc}
+     * @return The {@link SlashCommandModel} instance, for chaining.
+     * @see #getMain() getMain()
+     */
+    @Override
+    public @NotNull SlashCommandModel setMain(@Nullable Method main) {
+        this.main = main;
+
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param name {@inheritDoc}
+     * @return The {@link SlashCommandModel} instance, for chaining.
+     */
+    @Override
+    public @NotNull SlashCommandModel setName(@NotNull String name) {
+        this.name = name;
+
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param guildOnly {@inheritDoc}
+     * @return The {@link SlashCommandModel} instance, for chaining.
+     */
+    @Override
+    public @NotNull SlashCommandModel setGuildOnly(boolean guildOnly) {
+        this.guildOnly = guildOnly;
+
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param nsfw {@inheritDoc}
+     * @return The {@link SlashCommandModel} instance, for chaining.
+     */
+    @Override
+    public @NotNull SlashCommandModel setNSFW(boolean nsfw) {
+        this.nsfw = nsfw;
 
         return this;
     }


### PR DESCRIPTION
### Changes
- ✅ Internal
- ❌ Interface (affects end-user code)
- ❌ Gradle (wrapper, scripts, dependencies)
- ❌ Docs
- ❌ Metadata (README, copyright, Git files, files in `.github`)
- ❌ Other: ...
### Description
Move setters implementation to inherited classes (`CommandModel`) for more flexible API. Close todo: `Move setters to inherited classes and return (Slash/Prefix/Hybrid)CommandModel`.
